### PR TITLE
Progress circular rewrite first iteration

### DIFF
--- a/src/components/progressCircular/demoBasicUsage/index-old.html
+++ b/src/components/progressCircular/demoBasicUsage/index-old.html
@@ -1,0 +1,59 @@
+<div ng-controller="AppCtrl as vm" layout="column" layout-margin style="padding:25px;" ng-cloak>
+
+  <h4 style="margin-top:10px">Determinate</h4>
+
+  <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They
+    give users a quick sense of how long an operation will take.</p>
+
+  <div layout="row" layout-sm="column" layout-align="space-around">
+    <md-progress-circular md-mode="determinate" value="{{vm.determinateValue}}"></md-progress-circular>
+  </div>
+
+  <h4>Indeterminate</h4>
+
+  <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to
+    expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
+
+  <div layout="row" layout-sm="column" layout-align="space-around">
+    <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+  </div>
+
+  <h4>Theming </h4>
+
+  <p>
+    Your current theme colors can be used to easily colorize your progress indicator with `md-warn` or `md-accent`
+    colors.
+    To easily hide a <b>&lt;md-progress-circular&gt;</b> component, simply set the <b>md-mode</b> to "" or null.
+  </p>
+
+  <div layout="row" layout-sm="column" layout-align="space-around">
+    <md-progress-circular class="md-hue-2" md-mode="{{vm.modes[0]}}" md-diameter="20px"></md-progress-circular>
+    <md-progress-circular class="md-accent" md-mode="{{vm.modes[1]}}" md-diameter="40"></md-progress-circular>
+    <md-progress-circular class="md-accent md-hue-1" md-mode="{{vm.modes[2]}}" md-diameter="60"></md-progress-circular>
+    <md-progress-circular class="md-warn md-hue-3" md-mode="{{vm.modes[3]}}" md-diameter="70"></md-progress-circular>
+    <md-progress-circular md-mode="{{vm.modes[4]}}" md-diameter="96"></md-progress-circular>
+  </div>
+
+
+  <hr ng-class="{'visible' : vm.activated}">
+
+  <div id="loaders" layout="row" layout-align="start center">
+
+    <p>Progress Circular Indicators: </p>
+
+    <h5>Off</h5>
+    <md-switch
+        ng-model="vm.activated"
+        ng-change="vm.toggleActivation()"
+        aria-label="Toggle Progress Circular Indicators">
+      <h5>On</h5>
+    </md-switch>
+  </div>
+
+  <p class="small">
+    Note: With above switch -- that simply clears the md-mode in each <code>&lt;md-progress-linear md-mode=""&gt;</code>
+    element --
+    developers can easily disable the animations and hide their progress indicators.
+  </p>
+
+</div>

--- a/src/components/progressCircular/demoBasicUsage/index.html
+++ b/src/components/progressCircular/demoBasicUsage/index.html
@@ -1,59 +1,18 @@
 <div ng-controller="AppCtrl as vm" layout="column" layout-margin style="padding:25px;" ng-cloak>
+    <div layout="row" layout-align="center center" layout-sm="column">
+        <div flex="33" layout="column" layout-align="center center">
+            <h3>Current</h3>
+            <md-progress-circular md-mode="determinate" value="{{vm.determinateValue}}" md-diameter="{{vm.diameter}}"></md-progress-circular>
+        </div>
 
-  <h4 style="margin-top:10px">Determinate</h4>
+        <div flex="33" layout="column" layout-align="center center">
+            <h3>SVG Arc</h3>
+            <md-progress-circular-new value="{{vm.determinateValue}}" md-diameter="{{vm.diameter}}"></md-progress-circular-new>
+        </div>
 
-  <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They
-    give users a quick sense of how long an operation will take.</p>
-
-  <div layout="row" layout-sm="column" layout-align="space-around">
-    <md-progress-circular md-mode="determinate" value="{{vm.determinateValue}}"></md-progress-circular>
-  </div>
-
-  <h4>Indeterminate</h4>
-
-  <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to
-    expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
-
-  <div layout="row" layout-sm="column" layout-align="space-around">
-    <md-progress-circular md-mode="indeterminate"></md-progress-circular>
-  </div>
-
-  <h4>Theming </h4>
-
-  <p>
-    Your current theme colors can be used to easily colorize your progress indicator with `md-warn` or `md-accent`
-    colors.
-    To easily hide a <b>&lt;md-progress-circular&gt;</b> component, simply set the <b>md-mode</b> to "" or null.
-  </p>
-
-  <div layout="row" layout-sm="column" layout-align="space-around">
-    <md-progress-circular class="md-hue-2" md-mode="{{vm.modes[0]}}" md-diameter="20px"></md-progress-circular>
-    <md-progress-circular class="md-accent" md-mode="{{vm.modes[1]}}" md-diameter="40"></md-progress-circular>
-    <md-progress-circular class="md-accent md-hue-1" md-mode="{{vm.modes[2]}}" md-diameter="60"></md-progress-circular>
-    <md-progress-circular class="md-warn md-hue-3" md-mode="{{vm.modes[3]}}" md-diameter="70"></md-progress-circular>
-    <md-progress-circular md-mode="{{vm.modes[4]}}" md-diameter="96"></md-progress-circular>
-  </div>
-
-
-  <hr ng-class="{'visible' : vm.activated}">
-
-  <div id="loaders" layout="row" layout-align="start center">
-
-    <p>Progress Circular Indicators: </p>
-
-    <h5>Off</h5>
-    <md-switch
-        ng-model="vm.activated"
-        ng-change="vm.toggleActivation()"
-        aria-label="Toggle Progress Circular Indicators">
-      <h5>On</h5>
-    </md-switch>
-  </div>
-
-  <p class="small">
-    Note: With above switch -- that simply clears the md-mode in each <code>&lt;md-progress-linear md-mode=""&gt;</code>
-    element --
-    developers can easily disable the animations and hide their progress indicators.
-  </p>
-
+        <div flex="33" layout="column" layout-align="center center">
+            <h3>Stroke-dasharray</h3>
+            <md-progress-circular-new stroke-dasharray value="{{vm.determinateValue}}" md-diameter="{{vm.diameter}}"></md-progress-circular-new>
+        </div>
+    </div>
 </div>

--- a/src/components/progressCircular/demoBasicUsage/script.js
+++ b/src/components/progressCircular/demoBasicUsage/script.js
@@ -7,6 +7,7 @@ angular
       self.modes = [ ];
       self.activated = true;
       self.determinateValue = 30;
+      self.diameter = 100;
 
       /**
        * Turn off or on the 5 themed loaders

--- a/src/components/progressCircular/progress-circular-new.js
+++ b/src/components/progressCircular/progress-circular-new.js
@@ -1,0 +1,138 @@
+angular.module('material.components.progressCircularNew', ['material.core'])
+.directive('mdProgressCircularNew', MdProgressCircularNewDirective);
+
+function MdProgressCircularNewDirective($window) {
+  var DEFAULT_PROGRESS_SIZE = 100;
+  var DEFAULT_STROKE_WIDTH = 10;
+  var DEFAULT_ANIMATION_DURATION = 100;
+  var TAU = $window.Math.PI * 2;
+
+  return {
+    restrict: 'E',
+    scope: {
+      value: '@',
+      mdDiameter: '@'
+    },
+    template: function(element, attrs) {
+      return '<svg xmlns="http://www.w3.org/2000/svg">' +
+        '<'+ (attrs.hasOwnProperty('strokeDasharray') ? 'circle' : 'path') +
+        ' fill="none" stroke-width="'+ DEFAULT_STROKE_WIDTH +'"/>' +
+      '</svg>';
+    },
+    compile: function(element, attrs) {
+      if(attrs.hasOwnProperty('strokeDasharray')){
+        return dashArrayLink;
+      }
+
+      return arcLink;
+    }
+  };
+
+  function dashArrayLink(scope, element) {
+   var svg = angular.element(element[0].querySelector('svg'));
+   var circle = angular.element(element[0].querySelector('circle'));
+
+   scope.$watchGroup(['value', 'mdDiameter'], function(newValue){
+     var diameter = newValue[1] || DEFAULT_PROGRESS_SIZE;
+     var circleRadius = (diameter - DEFAULT_STROKE_WIDTH)/2;
+     var circumference = TAU * circleRadius;
+     var value = clamp(newValue[0])/100;
+
+     // technically this should also be the radius, but it shouldn't
+     // take the stroke width into account
+     var position = diameter/2;
+
+     svg.css({
+       width: diameter + 'px',
+       height: diameter + 'px'
+     });
+
+     svg[0].setAttribute('viewBox', '0 0 ' + diameter + ' ' + diameter);
+
+     circle.css({
+      // note that IE doesn't seem to transition this one.
+      // Edge only works if the units are included.
+      'stroke-dashoffset': (1 - value) * circumference + 'px',
+      'stroke-dasharray': circumference + 'px'
+     }).attr({
+      r: circleRadius,
+      cx: position,
+      cy: position,
+
+      // this is more conveniently done in the CSS, however
+      // rotating it with CSS doesn't appear to work in IE and Edge
+      transform: 'rotate(-90, '+ position +', '+ position +')'
+     });
+   });
+  }
+
+  function arcLink(scope, element) {
+    var svg = angular.element(element[0].querySelector('svg'));
+    var path = angular.element(element[0].querySelector('path'));
+    var lastAnimationId = 0;
+
+    scope.$watchGroup(['value', 'mdDiameter'], function(newValue, oldValue){
+      var animateFrom = clamp(oldValue[0]);
+      var changeInValue = clamp(newValue[0]) - animateFrom;
+      var animationDuration = DEFAULT_ANIMATION_DURATION;
+      var startTime = new $window.Date();
+      var diameter = newValue[1] || DEFAULT_PROGRESS_SIZE;
+
+      svg.css({
+        width: diameter + 'px',
+        height: diameter + 'px'
+      });
+
+      svg[0].setAttribute('viewBox', '0 0 ' + diameter + ' ' + diameter);
+
+      (function animation(){
+        var currentTime = $window.Math.min(new Date() - startTime, animationDuration);
+        var id = ++lastAnimationId;
+
+        path.attr('d', getSvgArc(
+          linearEase(currentTime, animateFrom, changeInValue, animationDuration),
+          diameter - DEFAULT_STROKE_WIDTH,
+          diameter
+        ));
+
+        if(id === lastAnimationId && currentTime < animationDuration){
+          $window.requestAnimationFrame(animation);
+        }
+      })();
+    });
+  }
+
+  function polarToCartesian(centerX, centerY, radius, angleInDegrees) {
+    var angleInRadians = (angleInDegrees - 90) * Math.PI / 180.0;
+
+    return {
+      x: centerX + (radius * Math.cos(angleInRadians)),
+      y: centerY + (radius * Math.sin(angleInRadians))
+    };
+  }
+
+  function getSvgArc(current, pathDiameter, diameter) {
+    var currentInDegrees = (current/100)*359.9999;
+    var radius = diameter/2;
+    var pathRadius = pathDiameter/2;
+    var start = polarToCartesian(radius, radius, pathRadius, currentInDegrees);
+    var end = polarToCartesian(radius, radius, pathRadius, 0);
+    var arcSweep = (currentInDegrees <= 180 ? "0" : "1");
+
+    return 'M ' + start.x + ' ' + start.y +
+           'A ' + pathRadius + ' ' + pathRadius +
+           ' ' + 0 + ' ' + arcSweep + ' ' + 0 + ' ' + end.x + ' ' + end.y;
+  }
+
+  function easeOutCubic(t, b, c, d) {
+    return c*((t=t/d-1)*t*t + 1) + b;
+  }
+
+  function linearEase(t, b, c, d) {
+    return c * t / d + b;
+  }
+
+  function clamp(value) {
+    return Math.max(0, Math.min(value || 0, 100));
+  }
+}

--- a/src/components/progressCircular/progress-circular-theme.scss
+++ b/src/components/progressCircular/progress-circular-theme.scss
@@ -69,3 +69,9 @@ md-progress-circular.md-THEME_NAME-theme {
     }
   }
 }
+
+md-progress-circular-new.md-THEME_NAME-theme{
+  path, circle{
+    stroke: '{{primary-color}}';
+  }
+}

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -137,6 +137,11 @@ md-progress-circular {
 
 }
 
+md-progress-circular-new {
+  circle {
+    transition: stroke-dashoffset 0.1s linear;
+  }
+}
 
 //
 // Keyframe animation for the Indeterminate Progress


### PR DESCRIPTION
Switches to using SVG for rendering the circular progress. Added two approaches to the
circular progress in order to do a side-by-side comparison and to determine which approach is better.
